### PR TITLE
Update homebridge-common.sh

### DIFF
--- a/Dockerfile.common
+++ b/Dockerfile.common
@@ -46,7 +46,7 @@ RUN alias ll='ls -alG'
 #RUN npm install
 
 RUN npm install -g homebridge
-RUN npm install -g homebridge-harmonyhub
+RUN npm install -g homebridge-openhab
 
 ##################################################
 # Start                                          #

--- a/homebridge-common.sh
+++ b/homebridge-common.sh
@@ -18,7 +18,7 @@ _build() {
 
 _run() {
   # Run (first time)
-  docker run -d -p 0.0.0.0:51826:51826 -v /root/.homebridge --net=host --name $IMAGE_NAME patrickbusch/homebridge:$VERSION
+  docker run -d -p 0.0.0.0:51826:51826 -v /etc/homebridge:/root/.homebridge --net=host --name $IMAGE_NAME patrickbusch/homebridge:$VERSION
 }
 
 _stop() {


### PR DESCRIPTION
changed the run command so that `/etc/homebridge` on the host will be mounted as `/root/.homebridge` in the container. This way the config dir remains on the host and survives updates/restarts.
