### PR TITLE
adding --no-check-certificate

### DIFF
--- a/Dockerfile.specific-PI
+++ b/Dockerfile.specific-PI
@@ -4,6 +4,6 @@
 
 #RUN curl -sLS https://apt.adafruit.com/add | sudo bash
 RUN echo "deb http://apt.adafruit.com/raspbian/ jessie main" >> /etc/apt/sources.list
-RUN wget -O - -q https://apt.adafruit.com/apt.adafruit.com.gpg.key | apt-key add -
+RUN wget --no-check-certificate -O - -q https://apt.adafruit.com/apt.adafruit.com.gpg.key | apt-key add -
 RUN apt-get update
 RUN apt-get install -y node


### PR DESCRIPTION
to avoid installing ca-certificates
fix for https://github.com/patrickbusch/homebridge-docker/issues/11
