### PR TITLE
Restart dbus in run.sh using Upstart (instead of directly starting daemon)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 
 sed -i "s/rlimit-nproc=3/#rlimit-nproc=3/" /etc/avahi/avahi-daemon.conf
 
-dbus-daemon --system
+service dbus restart
 avahi-daemon -D
 
 homebridge


### PR DESCRIPTION
Changes run.sh so that dbus is restarted using Upstart.

This fixes #13 for me, running on Ubuntu 16.10, since the Upstart script seems to handle pid errors gracefully. YMMV. 😉